### PR TITLE
Implement bounding box calculation on iOS

### DIFF
--- a/ios/VisionCameraFaceDetector.swift
+++ b/ios/VisionCameraFaceDetector.swift
@@ -81,8 +81,22 @@ public class VisionCameraFaceDetector: NSObject, FrameProcessorPluginBase {
     }
     
     private static func processBoundingBox(from face: Face) -> [String:Any] {
-        // TODO: implement bounding box calculations
-        return [:]
+        let frameRect = face.frame
+
+        let offsetX = (frameRect.midX - ceil(frameRect.width)) / 2.0
+        let offsetY = (frameRect.midY - ceil(frameRect.height)) / 2.0
+
+        let x = frameRect.maxX + offsetX
+        let y = frameRect.minY + offsetY
+
+        return [
+          "x": frameRect.midX + (frameRect.midX - x),
+          "y": frameRect.midY + (y - frameRect.midY),
+          "width": frameRect.width,
+          "height": frameRect.height,
+          "boundingCenterX": frameRect.midX,
+          "boundingCenterY": frameRect.midY
+        ]
     }
     
     @objc


### PR DESCRIPTION
`bounds` attribute on Face always returns empty object on iOS, this PR fixes it. Fix #3 