### PR TITLE
Add extra bounds to types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,10 @@ export interface Face {
     x: number;
     height: number;
     width: number;
+    boundingCenterX: number;
+    boundingCenterY: number;
+    boundingExactCenterX?: number;
+    boundingExactCenterY?: number;
   };
   contours: {
     FACE: Point[];


### PR DESCRIPTION
Adding some extra bounds that are declared on Android and iOS but not on the interface